### PR TITLE
fix(prettierrc): prettierrc jsx 내부도 홑따옴표로 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "semi": true,
   "singleQuote": true,
+  "jsxSingleQuote": true,
   "tabWidth": 2,
   "useTabs": false,
   "trailingComma": "es5"


### PR DESCRIPTION
## 무엇이 원인이었나요?
.prettierrc 파일 내부에 `jsxSingleQuote` 옵션이 빠져있었네요 :sweat_smile: 