### PR TITLE
[FEAT] InputUI

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,65 @@
+import { InputHTMLAttributes, useState } from 'react';
+import Image from 'next/image';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  placeholder?: string;
+  errorMessage?: string;
+  isPasswordVisible?: boolean;
+  isPassword?: boolean;
+}
+
+const Input = ({
+  label,
+  errorMessage,
+  placeholder,
+  isPasswordVisible = false,
+  isPassword = false,
+  ...props
+}: InputProps) => {
+  const baseBorder = 'border border-[var(--color-gray-100)]';
+  const focusBorder =
+    'focus:border-[var(--color-primary-500)] focus:outline-none';
+  const errorBorder = errorMessage ? 'border-[var(--color-red-500)]' : '';
+
+  const [showPassword, setShowPassword] = useState(false);
+  const togglePassword = () => setShowPassword((prev) => !prev);
+
+  return (
+    <div className='flex flex-col gap-[10px]'>
+      <label className='font-medium text-base'>{label}</label>
+      <div className='relative'>
+        <input
+          {...props}
+          type={isPassword && !showPassword ? 'password' : 'text'}
+          className={`${baseBorder} ${focusBorder} ${errorBorder} rounded-[16px] w-full pt-4 pr-10 pb-4 pl-5 transition-colors duration-200 font-medium`}
+          placeholder={placeholder}
+        />
+        {isPasswordVisible && (
+          <button type='button' onClick={togglePassword}>
+            <Image
+              src={
+                showPassword
+                  ? '/images/icons/EyeOpenIcon.svg'
+                  : '/images/icons/EyeOffIcon.svg'
+              }
+              alt='Eyes Icon'
+              width={24}
+              height={24}
+              className='absolute right-3 top-1/2 -translate-y-1/2'
+            />
+          </button>
+        )}
+      </div>
+      <span
+        className={`text-[12px] min-h-[20px] font-medium pl-2 ${
+          errorMessage ? 'text-[var(--color-red-500)] visible' : 'invisible'
+        }`}
+      >
+        {errorMessage || ' '}
+      </span>
+    </div>
+  );
+};
+
+export default Input;


### PR DESCRIPTION
# InputUI
- 로그인 회원가입 input과 내 체험 등록 페이지에 사용되는 inputUI 추가
- `isPasswordVisible`을 통해 icon 설정 할 수 있습니다

# 스크린샷
<img width="374" height="124" alt="스크린샷 2025-08-26 오후 3 15 48" src="https://github.com/user-attachments/assets/c85dbcff-4aa2-400c-9fee-b805616866b6" />
