### PR TITLE
[Feat] 유저 메뉴 드롭다운 구현

### DIFF
--- a/src/components/primitives/global/Header/LoggingInGnb.tsx
+++ b/src/components/primitives/global/Header/LoggingInGnb.tsx
@@ -2,9 +2,11 @@ import Image from 'next/image';
 import BellIcon from '@/public/images/icons/Bell.svg';
 import { useState } from 'react';
 import NotificationModal from '../../notification/NotificationModal';
+import UserMenuDropdown from './\bUserMenuDropdown';
 
 export default function LoggingInGnb() {
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 
   return (
     <div className='relative'>
@@ -13,13 +15,30 @@ export default function LoggingInGnb() {
           <button onClick={() => setIsModalVisible(!isModalVisible)}>
             <BellIcon />
           </button>
+
           {isModalVisible && (
-            <NotificationModal setVisible={setIsModalVisible} />
+            <>
+              <div
+                className='fixed inset-0 z-10'
+                onClick={() => setIsModalVisible(false)}
+              />
+
+              <div
+                className='absolute top-full left-1/2 -translate-x-1/2 mt-2 z-20'
+                onClick={(e) => e.stopPropagation()}
+              >
+                <NotificationModal setVisible={setIsModalVisible} />
+              </div>
+            </>
           )}
         </div>
+
         <span className='w-[1px] h-[14px] bg-gray-100' />
         <div className='relative'>
-          <button className='flex items-center gap-[10px]'>
+          <button
+            className='flex items-center gap-[10px]'
+            onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
+          >
             <Image
               src='/images/UserDefaultImg.svg'
               width={30}
@@ -28,6 +47,22 @@ export default function LoggingInGnb() {
             />
             <strong className='text-14 font-medium'>홍길동</strong>
           </button>
+
+          {isUserMenuOpen && (
+            <>
+              <div
+                className='fixed inset-0 z-10'
+                onClick={() => setIsUserMenuOpen(false)}
+              />
+
+              <div
+                className='absolute top-full right-[-4px] md:right-[-10px] mt-2 z-20'
+                onClick={(e) => e.stopPropagation()}
+              >
+                <UserMenuDropdown setVisible={setIsUserMenuOpen} />
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/primitives/global/Header/LoggingInGnb.tsx
+++ b/src/components/primitives/global/Header/LoggingInGnb.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import BellIcon from '@/public/images/icons/Bell.svg';
 import { useState } from 'react';
 import NotificationModal from '../../notification/NotificationModal';
-import UserMenuDropdown from './\bUserMenuDropdown';
+import UserMenuDropdown from './UserMenuDropdown';
 
 export default function LoggingInGnb() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -24,7 +24,7 @@ export default function LoggingInGnb() {
               />
 
               <div
-                className='absolute top-full left-1/2 -translate-x-1/2 mt-2 z-20'
+                className='absolute top-full left-1/2 -translate-x-1/2 mt-2 z-20 rounded-2xl shadow-[0_4px_24px_0_#9CB4CA33]'
                 onClick={(e) => e.stopPropagation()}
               >
                 <NotificationModal setVisible={setIsModalVisible} />
@@ -56,7 +56,7 @@ export default function LoggingInGnb() {
               />
 
               <div
-                className='absolute top-full right-[-4px] md:right-[-10px] mt-2 z-20'
+                className='absolute top-full right-[-4px] md:right-[-10px] mt-2 z-20 shadow-[0_4px_24px_0_#9CB4CA33]'
                 onClick={(e) => e.stopPropagation()}
               >
                 <UserMenuDropdown setVisible={setIsUserMenuOpen} />

--- a/src/components/primitives/global/Header/UserMenuDropdown.tsx
+++ b/src/components/primitives/global/Header/UserMenuDropdown.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import logout from '@/src/services/primitives/logout';
+import { useRouter } from 'next/navigation';
+
+export default function UserMenuDropdown({
+  setVisible,
+}: {
+  setVisible: (state: boolean) => void;
+}) {
+  const router = useRouter();
+
+  const handleMypageClick = () => {
+    setVisible(false);
+    router.push('/myInfo');
+  };
+
+  return (
+    <div className='flex flex-col justify-around items-center w-32 py-2 bg-white border border-[#dfdfdf] rounded-lg'>
+      <button
+        type='button'
+        className='px-4 py-2 text-14 lg:text-16 font-medium text-left'
+        aria-label='마이페이지로 이동'
+        onClick={handleMypageClick}
+      >
+        마이페이지
+      </button>
+      <button
+        type='button'
+        className='px-4 py-2 text-14 lg:text-16 font-medium text-left'
+        aria-label='로그아웃'
+        onClick={() => logout()}
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+}

--- a/src/components/primitives/notification/NotificationModal.tsx
+++ b/src/components/primitives/notification/NotificationModal.tsx
@@ -8,9 +8,7 @@ export default function NotificationModal({
   setVisible: (state: boolean) => void;
 }) {
   return (
-    <div
-      className={'w-[231px] h-48 pt-4 pb-2 z-[2] bg-white rounded-2xl shadow'}
-    >
+    <div className='w-[231px] h-48 pt-4 pb-2 bg-white rounded-2xl'>
       <div className='px-6 pb-3.5 flex justify-between border-b border-gray-100'>
         <h2 className='text-16 font-bold'>알림 6개</h2>
         <button onClick={() => setVisible(false)}>

--- a/src/components/primitives/notification/NotificationModal.tsx
+++ b/src/components/primitives/notification/NotificationModal.tsx
@@ -9,9 +9,7 @@ export default function NotificationModal({
 }) {
   return (
     <div
-      className={
-        'w-[231px] h-48 pt-4 pb-2 z-[2] absolute top-10 -translate-x-1/2 bg-white rounded-2xl shadow'
-      }
+      className={'w-[231px] h-48 pt-4 pb-2 z-[2] bg-white rounded-2xl shadow'}
     >
       <div className='px-6 pb-3.5 flex justify-between border-b border-gray-100'>
         <h2 className='text-16 font-bold'>알림 6개</h2>


### PR DESCRIPTION
## 작업 내용
- 브랜치를 따로 빼서 작업해서 이부분만 PR올리겠습니다.
- 로그아웃, 마이페이지 이동 드롭다운 연결했습니다.
- 드롭다운 외부 클릭 시 닫히도록하여 따로 X 표시는 만들지 않았습니다.
- NotificationModal도 외부 클릭 시 닫히도록 구현했습니다.
- 추가 의견 말씀해주시면 수정하겠습니다!

## 스크린샷
<img width="335" height="450" alt="image" src="https://github.com/user-attachments/assets/7da3cdd0-84a6-4820-9f7b-7b4cc58c22c3" />
