### PR TITLE
[Feat] 내 정보 페이지 구현

### DIFF
--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -25,9 +25,8 @@ export default function MyInfoPage() {
     register,
     handleSubmit,
     reset,
-    watch,
-    formState: { errors },
-  } = useForm<MyInfoFormData>({ mode: 'onBlur' });
+    formState: { errors, isValid },
+  } = useForm<MyInfoFormData>({ mode: 'onChange' });
 
   const { data: userInfo } = useQuery({
     queryKey: ['userInfo'],
@@ -38,18 +37,11 @@ export default function MyInfoPage() {
     if (userInfo) {
       reset({
         nickname: userInfo.nickname,
-        email: userInfo.email,
         password: '',
         checkpassword: '',
       });
     }
   }, [userInfo, reset]);
-
-  const watchedFields = watch();
-  const isButtonDisabled =
-    !watchedFields.nickname ||
-    !watchedFields.email ||
-    watchedFields.password !== watchedFields.checkpassword;
 
   const onSubmit = async (data: MyInfoFormData) => {
     const payload = {
@@ -61,7 +53,6 @@ export default function MyInfoPage() {
       await patchMyInfo(payload);
       reset({
         nickname: data.nickname,
-        email: data.email,
         password: '',
         checkpassword: '',
       });
@@ -105,14 +96,8 @@ export default function MyInfoPage() {
           label='이메일'
           variant='experience'
           placeholder='이메일을 입력하세요'
-          errorMessage={errors.email?.message}
-          {...register('email', {
-            required: '필수 입력 항목입니다.',
-            pattern: {
-              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-              message: '올바른 이메일 형식이 아닙니다.',
-            },
-          })}
+          defaultValue={userInfo?.email}
+          readOnly
         />
         <FormInput
           label='새 비밀번호'
@@ -132,8 +117,8 @@ export default function MyInfoPage() {
           errorMessage={errors.checkpassword?.message}
           {...register('checkpassword', {
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
-            validate: (value) =>
-              value === watch('password') || '비밀번호가 일치하지 않습니다.',
+            validate: (value, formValues) =>
+              value === formValues.password || '비밀번호가 일치하지 않습니다.',
           })}
         />
         <div className='w-full flex justify-center'>
@@ -141,7 +126,7 @@ export default function MyInfoPage() {
             type='submit'
             className='w-30'
             variant='primary'
-            disabled={isButtonDisabled}
+            disabled={!isValid}
           >
             저장하기
           </Button>

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -95,6 +95,7 @@ export default function MyInfoPage() {
               value: 10,
               message: '닉네임은 10자 이하로 작성해주세요.',
             },
+            pattern: { value: /^\S*$/, message: '공백 없이 입력해주세요.' },
           })}
         />
         <FormInput
@@ -112,6 +113,7 @@ export default function MyInfoPage() {
           errorMessage={errors.password?.message}
           {...register('password', {
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
+            pattern: { value: /^\S*$/, message: '공백 없이 입력해주세요.' },
           })}
         />
         <FormInput
@@ -124,6 +126,7 @@ export default function MyInfoPage() {
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
             validate: (value, formValues) =>
               value === formValues.password || '비밀번호가 일치하지 않습니다.',
+            pattern: { value: /^\S*$/, message: '공백 없이 입력해주세요.' },
           })}
         />
         <div className='w-full flex justify-center'>

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -55,13 +55,16 @@ export default function MyInfoPage() {
 
   return (
     <section>
-      <div className='mb-7.5'>
+      <div className='mb-7.5 md:mb-8.5'>
         <h1 className='font-bold text-18 mb-2.5'>내 정보</h1>
         <p className='text-14 font-medium text-gray-500'>
           닉네임과 비밀번호를 수정하실 수 있습니다.
         </p>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4.5'>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex flex-col gap-4.5 md:gap-6'
+      >
         <FormInput
           label='닉네임'
           variant='experience'

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -1,7 +1,121 @@
+'use client';
+
+import Button from '@/src/components/primitives/Button';
+import FormInput from '@/src/components/primitives/input/FormInput';
+import AlertModal from '@/src/components/primitives/modal/AlertModal';
+import { patchMyInfo } from '@/src/services/pages/users/api';
+import getUserInfo from '@/src/services/primitives/getUserInfo';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+type MyInfoFormData = {
+  nickname: string;
+  email: string;
+  password: string;
+  checkpassword: string;
+};
+
 export default function MyInfoPage() {
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertMessage, setAlertMessage] = useState('');
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<MyInfoFormData>({ mode: 'onBlur' });
+
+  const { data: userInfo } = useQuery({
+    queryKey: ['userInfo'],
+    queryFn: getUserInfo,
+  });
+
+  useEffect(() => {
+    if (userInfo) {
+      reset({
+        nickname: userInfo.nickname,
+        email: userInfo.email,
+        password: '',
+        checkpassword: '',
+      });
+    }
+  }, [userInfo, reset]);
+
+  const onSubmit = async (data: MyInfoFormData) => {
+    try {
+      await patchMyInfo(data);
+      setAlertMessage('내 정보가 저장되었습니다!');
+      setAlertOpen(true);
+    } catch (err) {
+      setAlertMessage('저장에 실패했습니다.');
+      setAlertOpen(true);
+    }
+  };
+
   return (
-    <main>
-      <h1>내 정보</h1>
-    </main>
+    <section>
+      <div className='mb-7.5'>
+        <h1 className='font-bold text-18 mb-2.5'>내 정보</h1>
+        <p className='text-14 font-medium text-gray-500'>
+          닉네임과 비밀번호를 수정하실 수 있습니다.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-4.5'>
+        <FormInput
+          label='닉네임'
+          variant='experience'
+          placeholder='닉네임을 입력하세요'
+          errorMessage={errors.nickname?.message}
+          {...register('nickname', { required: '필수 입력 항목입니다.' })}
+        />
+        <FormInput
+          label='이메일'
+          variant='experience'
+          placeholder='이메일을 입력하세요'
+          errorMessage={errors.email?.message}
+          {...register('email', {
+            required: '필수 입력 항목입니다.',
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: '올바른 이메일 형식이 아닙니다.',
+            },
+          })}
+        />
+        <FormInput
+          label='비밀번호'
+          isPassword={true}
+          variant='experience'
+          placeholder='8자 이상 입력해 주세요'
+          errorMessage={errors.password?.message}
+          {...register('password', {
+            required: '필수 입력 항목입니다.',
+            minLength: { value: 8, message: '8자 이상 입력해주세요.' },
+          })}
+        />
+        <FormInput
+          label='비밀번호 확인'
+          isPassword={true}
+          variant='experience'
+          placeholder='비밀번호를 한 번 더 입력해 주세요'
+          errorMessage={errors.checkpassword?.message}
+          {...register('checkpassword', {
+            required: '필수 입력 항목입니다.',
+            minLength: { value: 8, message: '8자 이상 입력해주세요.' },
+          })}
+        />
+        <div className='w-full flex justify-center'>
+          <Button type='submit' className='w-30' variant='primary'>
+            저장하기
+          </Button>
+        </div>
+      </form>
+
+      <AlertModal
+        isOpen={alertOpen}
+        message={alertMessage}
+        onClose={() => setAlertOpen(false)}
+      />
+    </section>
   );
 }

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -25,6 +25,7 @@ export default function MyInfoPage() {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = useForm<MyInfoFormData>({ mode: 'onBlur' });
 
@@ -43,6 +44,14 @@ export default function MyInfoPage() {
       });
     }
   }, [userInfo, reset]);
+
+  const watchedFields = watch();
+  const isButtonDisabled =
+    !watchedFields.nickname ||
+    !watchedFields.email ||
+    !watchedFields.password ||
+    !watchedFields.checkpassword ||
+    watchedFields.password !== watchedFields.checkpassword;
 
   const onSubmit = async (data: MyInfoFormData) => {
     try {
@@ -110,10 +119,17 @@ export default function MyInfoPage() {
           {...register('checkpassword', {
             required: '필수 입력 항목입니다.',
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
+            validate: (value) =>
+              value === watch('password') || '비밀번호가 일치하지 않습니다.',
           })}
         />
         <div className='w-full flex justify-center'>
-          <Button type='submit' className='w-30' variant='primary'>
+          <Button
+            type='submit'
+            className='w-30'
+            variant='primary'
+            disabled={isButtonDisabled}
+          >
             저장하기
           </Button>
         </div>

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -115,7 +115,7 @@ export default function MyInfoPage() {
           })}
         />
         <FormInput
-          label='비밀번호'
+          label='새 비밀번호'
           isPassword={true}
           variant='experience'
           placeholder='8자 이상 입력해 주세요'

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import Button from '@/src/components/primitives/Button';
-import FormInput from '@/src/components/primitives/input/FormInput';
-import AlertModal from '@/src/components/primitives/modal/AlertModal';
-import { patchMyInfo } from '@/src/services/pages/users/api';
-import getUserInfo from '@/src/services/primitives/getUserInfo';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+
+import { patchMyInfo } from '@/src/services/pages/users/api';
+import Button from '@/src/components/primitives/Button';
+import FormInput from '@/src/components/primitives/input/FormInput';
+import AlertModal from '@/src/components/primitives/modal/AlertModal';
+import BackBtn from '@/src/components/primitives/mypage/BackBtn';
+import getUserInfo from '@/src/services/primitives/getUserInfo';
 
 type MyInfoFormData = {
   nickname: string;
@@ -55,11 +57,14 @@ export default function MyInfoPage() {
 
   return (
     <section>
-      <div className='mb-7.5 md:mb-8.5'>
-        <h1 className='font-bold text-18 mb-2.5'>내 정보</h1>
-        <p className='text-14 font-medium text-gray-500'>
-          닉네임과 비밀번호를 수정하실 수 있습니다.
-        </p>
+      <div className='flex items-center gap-4 mb-7.5 md:mb-8.5'>
+        <BackBtn />
+        <div>
+          <h1 className='font-bold text-18 mb-2.5'>내 정보</h1>
+          <p className='text-14 font-medium text-gray-500'>
+            닉네임과 비밀번호를 수정하실 수 있습니다
+          </p>
+        </div>
       </div>
       <form
         onSubmit={handleSubmit(onSubmit)}

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -70,7 +70,7 @@ export default function MyInfoPage() {
   };
 
   return (
-    <section>
+    <>
       <div className='flex items-center gap-4 mb-7.5 md:mb-8.5'>
         <BackBtn />
         <div>
@@ -143,6 +143,6 @@ export default function MyInfoPage() {
         message={alertMessage}
         onClose={() => setAlertOpen(false)}
       />
-    </section>
+    </>
   );
 }

--- a/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
+++ b/src/app/(global)/(mypage)/myInfo/_components/myInfo.tsx
@@ -14,8 +14,8 @@ import getUserInfo from '@/src/services/primitives/getUserInfo';
 type MyInfoFormData = {
   nickname: string;
   email: string;
-  password: string;
-  checkpassword: string;
+  password?: string;
+  checkpassword?: string;
 };
 
 export default function MyInfoPage() {
@@ -49,13 +49,22 @@ export default function MyInfoPage() {
   const isButtonDisabled =
     !watchedFields.nickname ||
     !watchedFields.email ||
-    !watchedFields.password ||
-    !watchedFields.checkpassword ||
     watchedFields.password !== watchedFields.checkpassword;
 
   const onSubmit = async (data: MyInfoFormData) => {
+    const payload = {
+      ...data,
+      ...(data.password ? { password: data.password } : {}),
+    };
+
     try {
-      await patchMyInfo(data);
+      await patchMyInfo(payload);
+      reset({
+        nickname: data.nickname,
+        email: data.email,
+        password: '',
+        checkpassword: '',
+      });
       setAlertMessage('내 정보가 저장되었습니다!');
       setAlertOpen(true);
     } catch (err) {
@@ -84,7 +93,13 @@ export default function MyInfoPage() {
           variant='experience'
           placeholder='닉네임을 입력하세요'
           errorMessage={errors.nickname?.message}
-          {...register('nickname', { required: '필수 입력 항목입니다.' })}
+          {...register('nickname', {
+            required: '필수 입력 항목입니다.',
+            maxLength: {
+              value: 10,
+              message: '닉네임은 10자 이하로 작성해주세요.',
+            },
+          })}
         />
         <FormInput
           label='이메일'
@@ -106,7 +121,6 @@ export default function MyInfoPage() {
           placeholder='8자 이상 입력해 주세요'
           errorMessage={errors.password?.message}
           {...register('password', {
-            required: '필수 입력 항목입니다.',
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
           })}
         />
@@ -117,7 +131,6 @@ export default function MyInfoPage() {
           placeholder='비밀번호를 한 번 더 입력해 주세요'
           errorMessage={errors.checkpassword?.message}
           {...register('checkpassword', {
-            required: '필수 입력 항목입니다.',
             minLength: { value: 8, message: '8자 이상 입력해주세요.' },
             validate: (value) =>
               value === watch('password') || '비밀번호가 일치하지 않습니다.',

--- a/src/app/(global)/(mypage)/myInfo/page.tsx
+++ b/src/app/(global)/(mypage)/myInfo/page.tsx
@@ -56,8 +56,7 @@ export default function MypageLayout() {
       <section className='w-full pt-[85px] pb-[64px] overflow-hidden md:pt-[120px] md:pb-[54px] h-full'>
         <div
           className={cn(
-            'flex w-[200vw] transition-all md:w-[calc(100%-60px)] md:gap-[30px] md:max-w-[980px] md:mx-auto lg:gap-[50px] h-[480px]',
-            isTabOpen && '-translate-x-1/2 md:translate-x-0 h-auto'
+            'flex w-[200vw] transition-all md:w-[calc(100%-60px)] md:gap-[30px] md:max-w-[980px] md:mx-auto lg:gap-[50px] -translate-x-1/2 md:translate-x-0 h-auto'
           )}
         >
           <div className='w-screen px-6 shrink-0 md:w-[178px] md:px-0 lg:w-[290px]'>
@@ -69,8 +68,7 @@ export default function MypageLayout() {
           </div>
           <article
             className={cn(
-              'w-screen px-6 shrink-0 md:w-auto md:shrink-1 md:px-0 md:grow-1',
-              isTabOpen && 'h-100%'
+              'w-screen h-100% px-6 shrink-0 md:w-auto md:shrink-1 md:px-0 md:grow-1'
             )}
           >
             <Tabs page={tab} />

--- a/src/components/pages/sidebar/ProfilePicture.tsx
+++ b/src/components/pages/sidebar/ProfilePicture.tsx
@@ -29,9 +29,10 @@ export default function ProfilePicture() {
   return (
     <div className='relative h-[120px] md:h-[70px] lg:h-[120px] aspect-square'>
       {userData && userData.profileImageUrl ? (
-        <img
+        <Image
           src={userData.profileImageUrl}
           alt={`${userData.nickname}의 아바타`}
+          fill
           className='w-full h-full rounded-full object-cover'
         />
       ) : (

--- a/src/components/primitives/global/Header/LoggingInGnb.tsx
+++ b/src/components/primitives/global/Header/LoggingInGnb.tsx
@@ -3,10 +3,13 @@ import BellIcon from '@/public/images/icons/Bell.svg';
 import { useState } from 'react';
 import NotificationModal from '../../notification/NotificationModal';
 import UserMenuDropdown from './UserMenuDropdown';
+import useCurrentUser from '@/src/hooks/useCurrentUser';
 
 export default function LoggingInGnb() {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+
+  const userInfo = useCurrentUser();
 
   return (
     <div className='relative'>
@@ -40,12 +43,15 @@ export default function LoggingInGnb() {
             onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
           >
             <Image
-              src='/images/UserDefaultImg.svg'
+              src={userInfo?.profileImageUrl || '/images/UserDefaultImg.svg'}
               width={30}
               height={30}
-              alt='유저 기본 이미지'
+              className='w-7.5 h-7.5 rounded-full object-cover'
+              alt='유저 프로필 이미지'
             />
-            <strong className='text-14 font-medium'>홍길동</strong>
+            <strong className='text-14 font-medium'>
+              {userInfo?.nickname || '홍길동'}
+            </strong>
           </button>
 
           {isUserMenuOpen && (

--- a/src/components/primitives/input/FormInput.tsx
+++ b/src/components/primitives/input/FormInput.tsx
@@ -35,7 +35,8 @@ const FormInput = forwardRef<
         variant === 'experience' || variant === 'auth',
     });
 
-    const baseBorder = 'border border-gray-100';
+    const baseBorder = 'border border-gray-100 shadow-[0_2px_6px_0_#00000005]';
+
     const focusBorder =
       'focus:border-[var(--color-primary-500)] focus:outline-none';
     const errorBorder = errorMessage ? 'border-red-500' : '';


### PR DESCRIPTION
## 작업 내용
- 닉네임, 이메일, 비밀번호를 수정할 수 있는 페이지 구현했습니다.
- 닉네임과 이메일은 기존 유저 정보를 가져와 기본값으로 넣었습니다.
- 비밀번호는 옵셔널로 설정하여 수정할 경우에만 유효성 검사를 진행할 수 있도록 했습니다.
- 정보 저장 성공 및 실패 시 모달로 알림 처리했습니다.

## 스크린샷
<img width="484" height="678" alt="image" src="https://github.com/user-attachments/assets/252e8176-1e44-4144-978c-021e10fb45fb" />
<img width="484" height="678" alt="image" src="https://github.com/user-attachments/assets/15dee0a8-1ad8-4e46-9641-c451e52f01ef" />
<img width="484" height="678" alt="image" src="https://github.com/user-attachments/assets/7ffce57f-b67b-40fe-a23d-d775490a9936" />
<img width="484" height="678" alt="image" src="https://github.com/user-attachments/assets/7d0aa361-bb85-474c-abfb-d3fdb88dc79c" />
