### PR TITLE
[Feat] 페이지네이션 구현

### DIFF
--- a/public/images/icons/ChevronLeftIcon.svg
+++ b/public/images/icons/ChevronLeftIcon.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22.1465 14.293L16.4395 20L22.1465 25.707L23.5605 24.293L19.2675 20L23.5605 15.707L22.1465 14.293Z" fill="currentColor"/>
+</svg>

--- a/public/images/icons/ChevronRightIcon.svg
+++ b/public/images/icons/ChevronRightIcon.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.8535 25.707L23.5605 20L17.8535 14.293L16.4395 15.707L20.7325 20L16.4395 24.293L17.8535 25.707Z" fill="currentColor"/>
+</svg>

--- a/src/components/pages/detail/ActivityDetail.tsx
+++ b/src/components/pages/detail/ActivityDetail.tsx
@@ -14,9 +14,7 @@ interface Props {
 }
 
 export default function ActivityDetail({ activity, reviewData }: Props) {
-  // 페이지네이션
   const [currentPage, setCurrentPage] = useState(1);
-  const totalPages = Math.ceil(reviewData.reviews.length / REVIEWS_PER_PAGE);
   const currentReviews = reviewData.reviews.slice(
     (currentPage - 1) * REVIEWS_PER_PAGE,
     currentPage * REVIEWS_PER_PAGE

--- a/src/components/pages/detail/ActivityDetail.tsx
+++ b/src/components/pages/detail/ActivityDetail.tsx
@@ -44,13 +44,13 @@ export default function ActivityDetail({ activity, reviewData }: Props) {
         <h2 className='inline-block text-16 font-bold mb-2 md:text-18 lg:mb-[9px]'>
           체험 후기{' '}
           <span className='text-gray-500 text-14 font-semibold'>
-            {activity.reviewCount}개
+            {activity.reviewCount.toLocaleString()}개
           </span>
         </h2>
 
         <div className='flex flex-col items-center w-full mb-7.5'>
           <p className='text-24 font-semibold mb-1 md:text-32 md:font-bold'>
-            {activity.rating}
+            {activity.rating.toFixed(1)}
           </p>
           <p className='text-14 font-bold mb-1.5 md:text-16'>
             <RatingText rating={activity.rating} />
@@ -60,7 +60,7 @@ export default function ActivityDetail({ activity, reviewData }: Props) {
               <Image src='/images/icons/StarFilled.svg' alt='체험별점' fill />
             </div>
             <span className='text-gray-500 text-14 font-medium'>
-              {activity.reviewCount}개의 후기
+              {activity.reviewCount.toLocaleString()}개의 후기
             </span>
           </div>
         </div>

--- a/src/components/pages/detail/ActivityDetail.tsx
+++ b/src/components/pages/detail/ActivityDetail.tsx
@@ -6,6 +6,7 @@ import { REVIEWS_PER_PAGE } from '@/src/constants/pagination';
 import { ReviewResponse } from '@/src/types/reviewType';
 import { Activity } from '@/src/types/activityType';
 import ReviewList from './ReviewList';
+import Pagination from '../../primitives/Pagination';
 
 interface Props {
   activity: Activity;
@@ -67,28 +68,13 @@ export default function ActivityDetail({ activity, reviewData }: Props) {
         {/* 리뷰 목록 */}
         <ReviewList reviews={currentReviews} />
 
-        {/* 임시 페이지네이션 UI  */}
-        {reviewData.reviews.length > REVIEWS_PER_PAGE && (
-          <div className='flex justify-center gap-2 w-full mt-10 mb-20'>
-            <button
-              disabled={currentPage === 1}
-              onClick={() => setCurrentPage((prev) => prev - 1)}
-            >
-              이전
-            </button>
-            {Array.from({ length: totalPages }, (_, i) => (
-              <button key={i + 1} onClick={() => setCurrentPage(i + 1)}>
-                {i + 1}
-              </button>
-            ))}
-            <button
-              disabled={currentPage === totalPages}
-              onClick={() => setCurrentPage((prev) => prev + 1)}
-            >
-              다음
-            </button>
-          </div>
-        )}
+        {/* 페이지네이션 */}
+        <Pagination
+          currentPage={currentPage}
+          totalItems={reviewData.reviews.length}
+          itemsPerPage={REVIEWS_PER_PAGE}
+          onPageChange={setCurrentPage}
+        />
       </section>
     </>
   );

--- a/src/components/pages/detail/ActivityInfo.tsx
+++ b/src/components/pages/detail/ActivityInfo.tsx
@@ -1,8 +1,8 @@
-import { Activity } from '@/src/types/activityType';
 import Image from 'next/image';
 import DropdownList from './DrowdownList';
 import { useDropdown } from '@/src/hooks/pages/detail/useDropdown';
 import useCurrentUser from '@/src/hooks/useCurrentUser';
+import { Activity } from '@/src/types/activityType';
 
 interface Props {
   activity: Activity;
@@ -31,7 +31,8 @@ export default function ActivityInfo({ activity }: Props) {
               <Image src='/images/icons/StarFilled.svg' alt='체험별점' fill />
             </div>
             <span className='text-gray-700 text-14 font-medium'>
-              {activity.rating}({activity.reviewCount})
+              {activity.rating.toFixed(1)} (
+              {activity.reviewCount.toLocaleString()})
             </span>
           </div>
           <div className='flex gap-0.5 lg:mb-4'>

--- a/src/components/pages/detail/DrowdownList.tsx
+++ b/src/components/pages/detail/DrowdownList.tsx
@@ -11,7 +11,7 @@ export default function DropdownList({ activityId }: Props) {
   return (
     <>
       <div className='flex flex-col justify-around w-24 h-27 bg-white border border-[#dfdfdf] rounded-[8px] shadow-[0px_0px_3px_0px_#dde6ef]'>
-        <UpdateActivityButton />
+        <UpdateActivityButton activityId={activityId} />
         <DeleteActivityButton activityId={activityId} />
       </div>
     </>

--- a/src/components/pages/detail/ResponsiveLayout.tsx
+++ b/src/components/pages/detail/ResponsiveLayout.tsx
@@ -27,10 +27,10 @@ export default function ResponsiveLayout({ activity, reviewData }: Props) {
   }, [isPopupVisible, isLg]);
 
   return (
-    <div className='mt-12'>
+    <div>
       {isLg ? (
         // 데스크탑
-        <div className='flex justify-center gap-10 mx-0'>
+        <div className='flex justify-center gap-10 pt-22 mt-20 mx-0'>
           <div className='max-w-[670px] w-full'>
             <ActivityImage activity={activity} />
             <ActivityDetail activity={activity} reviewData={reviewData} />
@@ -41,12 +41,12 @@ export default function ResponsiveLayout({ activity, reviewData }: Props) {
           </div>
         </div>
       ) : (
+        // 테블릿 / 모바일
         <div
-          className={`mt-12 px-5 ${
+          className={`mt-12 md:mt-20 pt-7.5 md:pt-[34px] px-5 ${
             isPopupVisible ? 'overflow-hidden' : 'overflow-auto'
           }`}
         >
-          {/* 테블릿 / 모바일 */}
           <ActivityImage activity={activity} />
           <ActivityInfo activity={activity} />
           <ActivityDetail activity={activity} reviewData={reviewData} />

--- a/src/components/pages/detail/ResponsiveLayout.tsx
+++ b/src/components/pages/detail/ResponsiveLayout.tsx
@@ -38,12 +38,13 @@ export default function ResponsiveLayout({ activity, reviewData }: Props) {
           <div className='max-w-[410px] w-full'>
             <ActivityInfo activity={activity} />
             <ReservationUI activity={activity} />
-            {/* 예약 컴포넌트 들어갈 자리 */}
           </div>
         </div>
       ) : (
         <div
-          className={`mt-12 px-5 ${isPopupVisible ? 'overflow-hidden' : 'overflow-auto'}`}
+          className={`mt-12 px-5 ${
+            isPopupVisible ? 'overflow-hidden' : 'overflow-auto'
+          }`}
         >
           {/* 테블릿 / 모바일 */}
           <ActivityImage activity={activity} />
@@ -63,7 +64,6 @@ export default function ResponsiveLayout({ activity, reviewData }: Props) {
               setIsPopupVisible={setIsPopupVisible}
             />
           </PopupWrapper>
-          {/* 예약 컴포넌트 들어갈 자리 */}
         </div>
       )}
     </div>

--- a/src/components/pages/detail/ReviewList.tsx
+++ b/src/components/pages/detail/ReviewList.tsx
@@ -34,7 +34,7 @@ export default function ReviewList({ reviews }: Props) {
             <span className='text-gray-300 text-12 font-semibold md:text-14 md:font-medium'>
               {format(
                 review.updatedAt ? review.updatedAt : review.createdAt,
-                'yyyy. M. dd'
+                'yyyy. M. d'
               )}
             </span>
           </h3>

--- a/src/components/primitives/Pagination.tsx
+++ b/src/components/primitives/Pagination.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/src/utils/cn';
 import LeftIcon from '@/public/images/icons/ChevronLeftIcon.svg';
 import RightIcon from '@/public/images/icons/ChevronRightIcon.svg';
+import { useMemo } from 'react';
 
 interface Props {
   currentPage: number;
@@ -15,9 +16,18 @@ export default function Pagination({
   itemsPerPage,
   onPageChange,
 }: Props) {
+  const visiblePages = 5;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
   if (totalPages <= 1) return null;
+
+  const pages = useMemo(() => {
+    const start =
+      Math.floor((currentPage - 1) / visiblePages) * visiblePages + 1;
+    const end = Math.min(start + visiblePages - 1, totalPages);
+
+    return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+  }, [currentPage, totalPages]);
 
   return (
     <div className='flex justify-center gap-2 w-full mt-10 mb-20'>
@@ -29,18 +39,18 @@ export default function Pagination({
         <LeftIcon className='w-10 h-10' />
       </button>
 
-      {Array.from({ length: totalPages }, (_, i) => (
+      {pages.map((page) => (
         <button
-          key={i + 1}
+          key={page}
+          onClick={() => onPageChange(page)}
           className={cn(
             'w-10 h-10',
-            currentPage === i + 1
+            currentPage === page
               ? 'font-bold border-b-2 border-primary-500'
               : 'font-medium text-gray-300'
           )}
-          onClick={() => onPageChange(i + 1)}
         >
-          {i + 1}
+          {page}
         </button>
       ))}
 

--- a/src/components/primitives/Pagination.tsx
+++ b/src/components/primitives/Pagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@/src/utils/cn';
 import LeftIcon from '@/public/images/icons/ChevronLeftIcon.svg';
 import RightIcon from '@/public/images/icons/ChevronRightIcon.svg';
@@ -19,8 +21,6 @@ export default function Pagination({
   const visiblePages = 5;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
 
-  if (totalPages <= 1) return null;
-
   const pages = useMemo(() => {
     const start =
       Math.floor((currentPage - 1) / visiblePages) * visiblePages + 1;
@@ -28,6 +28,8 @@ export default function Pagination({
 
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
   }, [currentPage, totalPages]);
+
+  if (totalPages <= 1) return null;
 
   return (
     <div className='flex justify-center gap-2 w-full mt-10 mb-20'>

--- a/src/components/primitives/Pagination.tsx
+++ b/src/components/primitives/Pagination.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/src/utils/cn';
+import LeftIcon from '@/public/images/icons/ChevronLeftIcon.svg';
+import RightIcon from '@/public/images/icons/ChevronRightIcon.svg';
+
+interface Props {
+  currentPage: number;
+  totalItems: number;
+  itemsPerPage: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({
+  currentPage,
+  totalItems,
+  itemsPerPage,
+  onPageChange,
+}: Props) {
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className='flex justify-center gap-2 w-full mt-10 mb-20'>
+      <button
+        disabled={currentPage === 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        className='disabled:text-gray-300'
+      >
+        <LeftIcon className='w-10 h-10' />
+      </button>
+
+      {Array.from({ length: totalPages }, (_, i) => (
+        <button
+          key={i + 1}
+          className={cn(
+            'w-10 h-10',
+            currentPage === i + 1
+              ? 'font-bold border-b-2 border-primary-500'
+              : 'font-medium text-gray-300'
+          )}
+          onClick={() => onPageChange(i + 1)}
+        >
+          {i + 1}
+        </button>
+      ))}
+
+      <button
+        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        className='disabled:text-gray-300'
+      >
+        <RightIcon className='w-10 h-10' />
+      </button>
+    </div>
+  );
+}

--- a/src/components/primitives/UpdateActivityButton.tsx
+++ b/src/components/primitives/UpdateActivityButton.tsx
@@ -4,17 +4,21 @@ import { cn } from '@/src/utils/cn';
 import { useRouter } from 'next/navigation';
 
 interface Props {
+  activityId: number;
   onClick?: () => void;
   className?: string;
 }
 
-export default function UpdateActivityButton({ onClick, className }: Props) {
+export default function UpdateActivityButton({
+  onClick,
+  className,
+  activityId,
+}: Props) {
   const router = useRouter();
 
   const handleClick = () => {
     if (onClick) return onClick();
-    // 동적 라우팅으로 변경 예정 (수정 페이지 담당(성현님)과 소통 필요!)
-    router.push('/myUpdateExperiences');
+    router.push(`/myUpdateExperiences/${activityId}`);
   };
 
   return (

--- a/src/components/primitives/global/Header/Header.tsx
+++ b/src/components/primitives/global/Header/Header.tsx
@@ -10,7 +10,7 @@ export default function Header() {
 
   return (
     <header className='absolute top-0 left-0 right-0'>
-      <div className='flex justify-between items-center max-w-[1520px] h-12 mx-auto px-6 md:px-[30px] lg:px-0 lg:w-[calc(100%-60px)]'>
+      <div className='flex justify-between items-center max-w-[1520px] h-12 md:h-20 mx-auto px-6 md:px-[30px] lg:px-0 lg:w-[calc(100%-60px)]'>
         <h1>
           <Link href='/' className='w-7 md:w-[174px]'>
             <Image


### PR DESCRIPTION
## 작업 내용
- 페이지네이션 컴포넌트를 만들어 상세페이지와 연결했습니다.(스크린샷 내용은 mockData 입니다.)
- 메인페이지에 작업은 아직 진행하지 않았습니다.

## 페이지네이션 컴포넌트
- Prop
currentPage : 현재 선택된 페이지 번호
totalItems : 전체 아이템 개수
itemsPerPage : 한 페이지에 보여줄 아이템 개수
onPageChange : 페이지 변경 시 실행되는 콜백

## 사용 예시
```
const [currentPage, setCurrentPage] = useState(1);

<Pagination
  currentPage={currentPage}
  totalItems={reviews.length}
  itemsPerPage={REVIEWS_PER_PAGE}
  onPageChange={setCurrentPage}
/>
```

## 스크린샷
<img width="484" height="667" alt="image" src="https://github.com/user-attachments/assets/a3498826-b65a-4cc5-8b87-255959f502a1" />
<img width="416" height="109" alt="image" src="https://github.com/user-attachments/assets/6c7cee4c-93e8-4cbd-8234-6660454717da" />


