### PR TITLE
[FEAT] 체험 수정, 체험 이미지 생성 api 추가 & 수정과 등록에 따른 form관리

### DIFF
--- a/src/app/(global)/(mypage)/myCreateExperiences/page.tsx
+++ b/src/app/(global)/(mypage)/myCreateExperiences/page.tsx
@@ -5,11 +5,20 @@ import Dropdown from '@/src/components/pages/myCreateExperiences/Dropdown';
 import UploadBannerImage from '@/src/components/pages/myCreateExperiences/UploadBannerImage';
 import Button from '@/src/components/primitives/Button';
 import FormInput from '@/src/components/primitives/input/FormInput';
+import AlertModal from '@/src/components/primitives/modal/AlertModal';
+import ConfirmModal from '@/src/components/primitives/modal/ConfirmModal';
+import {
+  uploadActivityImage,
+  uploadActivityImages,
+} from '@/src/services/pages/createImageUrl/api';
+import { createExperience } from '@/src/services/pages/myCreateExperiences/api';
 import { useReservationStore } from '@/src/store/ReservationStore';
 import { useTimeSlotStore } from '@/src/store/TimeSlotStore';
 import { useActivityStore } from '@/src/store/useActivityStore';
 import { openDaumPostcode } from '@/src/utils/daumPostcode';
 import { format } from 'date-fns';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 
 interface Schedule {
@@ -35,6 +44,10 @@ export default function MyCreateExperiencesPage() {
     control,
     formState: { errors },
   } = useForm<ExperiencesFormData>({ mode: 'onBlur' });
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const router = useRouter();
 
   const handleAddressClick = async () => {
     try {
@@ -45,24 +58,64 @@ export default function MyCreateExperiencesPage() {
     }
   };
 
+  const handleCloseModal = () => {
+    router.back();
+  };
+
+  const handleConfirm = () => {
+    setIsConfirmOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsConfirmOpen(false);
+  };
+
   const { timeSlots } = useTimeSlotStore();
   const selectedDate = useReservationStore(
     (state) => state.dateSelector.selectedDate
   );
-  const { bannerImages } = useActivityStore();
+  const { bannerImages, subImages } = useActivityStore();
 
-  const onSubmit: SubmitHandler<ExperiencesFormData> = (data) => {
-    // timeSlots 배열을 schedules 형태로 변환
-    const schedules: Schedule[] = timeSlots
-      .filter((slot) => slot.startTime && slot.endTime)
-      .map((slot) => ({
-        date: selectedDate ? format(selectedDate, 'yyyy-MM-dd') : '',
-        startTime: slot.startTime!,
-        endTime: slot.endTime!,
-      }));
+  const onSubmit: SubmitHandler<ExperiencesFormData> = async (data) => {
+    console.log('소개 이미지 상태:', subImages);
+    try {
+      // 1️⃣ schedules 변환
+      const schedules: Schedule[] = timeSlots
+        .filter((slot) => slot.startTime && slot.endTime)
+        .map((slot) => ({
+          date: selectedDate ? format(selectedDate, 'yyyy-MM-dd') : '',
+          startTime: slot.startTime!,
+          endTime: slot.endTime!,
+        }));
 
-    console.log('폼 제출됨 ✅', { ...data, schedules, bannerImages });
+      // 2️⃣ 배너 이미지 업로드 (단일)
+      if (!bannerImages[0]) throw new Error('배너 이미지를 선택해주세요.');
+      const bannerUrl = await uploadActivityImage(bannerImages[0]);
+
+      // 3️⃣ 서브 이미지 업로드 (다중)
+      const subImageUrls = subImages.length
+        ? await uploadActivityImages(subImages)
+        : [];
+
+      console.log('업로드 후 소개 이미지 URL:', subImageUrls);
+
+      // 4️⃣ payload 생성
+      const payload = {
+        ...data,
+        schedules,
+        bannerImageUrl: bannerUrl,
+        subImageUrls,
+      };
+
+      // 5️⃣ 체험 등록 API 호출
+      const response = await createExperience(payload);
+      console.log('✅ 체험 등록 성공', response);
+      setIsAlertOpen(true);
+    } catch (error) {
+      console.error('❌ 체험 등록 실패', error);
+    }
   };
+
   return (
     <div>
       <form
@@ -85,7 +138,7 @@ export default function MyCreateExperiencesPage() {
             <Dropdown
               label='카테고리'
               items={[
-                '문화 ∙ 예술',
+                '문화 · 예술',
                 '식음료',
                 '스포츠',
                 '투어',
@@ -142,6 +195,17 @@ export default function MyCreateExperiencesPage() {
           </Button>
         </div>
       </form>
+      <AlertModal
+        isOpen={isAlertOpen}
+        message='체험 등록이 완료되었습니다'
+        onClose={handleCloseModal}
+      />
+      <ConfirmModal
+        isOpen={isConfirmOpen}
+        message='작업 중인 내용이 저장되지 않습니다. 정말 이동하시겠습니까?'
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
     </div>
   );
 }

--- a/src/app/(global)/(mypage)/myUpdateExperiences/[id]/page.tsx
+++ b/src/app/(global)/(mypage)/myUpdateExperiences/[id]/page.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Controller, useForm } from 'react-hook-form';
+import { format } from 'date-fns';
+
+import AvailableTimeSlots from '@/src/components/pages/myCreateExperiences/AvailableTimeSlots';
+import Dropdown from '@/src/components/pages/myCreateExperiences/Dropdown';
+import UploadBannerImage from '@/src/components/pages/myCreateExperiences/UploadBannerImage';
+import Button from '@/src/components/primitives/Button';
+import FormInput from '@/src/components/primitives/input/FormInput';
+
+import {
+  uploadActivityImage,
+  uploadActivityImages,
+} from '@/src/services/pages/createImageUrl/api';
+import {
+  getExperienceDetail,
+  updateExperience,
+  UpdateExperiencePayload,
+} from '@/src/services/pages/myUpdateExperiences/api';
+
+import { useReservationStore } from '@/src/store/ReservationStore';
+import { useTimeSlotStore } from '@/src/store/TimeSlotStore';
+import { useActivityStore } from '@/src/store/useActivityStore';
+import { openDaumPostcode } from '@/src/utils/daumPostcode';
+import AlertModal from '@/src/components/primitives/modal/AlertModal';
+
+interface Schedule {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface ExperiencesFormData {
+  title: string;
+  category: string;
+  description: string;
+  price: number;
+  address: string;
+  schedules: Schedule[];
+}
+
+export default function MyUpdateExperiencesPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [existingSubImages, setExistingSubImages] = useState<
+    { id: number; url: string }[]
+  >([]);
+
+  // ✅ 수정 전용 useForm
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<ExperiencesFormData>({
+    mode: 'onBlur',
+    defaultValues: {
+      title: '',
+      category: '',
+      description: '',
+      price: 0,
+      address: '',
+      schedules: [],
+    },
+  });
+
+  const handleAddressClick = async () => {
+    try {
+      const data = await openDaumPostcode();
+      setValue('address', data.address);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleCloseModal = () => {
+    router.back();
+  };
+
+  const { timeSlots, setTimeSlots } = useTimeSlotStore();
+  const { bannerImages, subImages, setBannerImages, setSubImages } =
+    useActivityStore();
+  const { setSelectedDate } = useReservationStore(
+    (state) => state.dateSelector
+  );
+
+  // 🆕 서버에서 받아온 기존 이미지(URL) 상태
+  const [bannerUrls, setBannerUrls] = useState<string[]>([]);
+  const [subUrls, setSubUrls] = useState<string[]>([]);
+
+  // 1️⃣ 기존 데이터 불러오기
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // console.log('id:', id);
+
+        const detail = await getExperienceDetail(id);
+
+        // form 값 세팅
+        reset({
+          title: detail.title,
+          category: detail.category,
+          description: detail.description,
+          price: detail.price,
+          address: detail.address,
+        });
+
+        // 이미지 상태 세팅
+        setBannerUrls([detail.bannerImageUrl]);
+        setSubUrls(
+          detail.subImages?.map(
+            (img: { id: number; imageUrl: string }) => img.imageUrl
+          ) ?? []
+        );
+
+        setExistingSubImages(detail.subImages ?? []);
+
+        // timeSlots & 날짜 세팅
+        setTimeSlots(
+          detail.schedules.map((s: Schedule) => ({
+            startTime: s.startTime,
+            endTime: s.endTime,
+          }))
+        );
+        if (detail.schedules.length > 0 && detail.schedules[0].date) {
+          setSelectedDate(new Date(detail.schedules[0].date));
+        }
+      } catch (error) {
+        console.error('❌ 체험 상세 불러오기 실패', error);
+      }
+    };
+    fetchData();
+  }, [id, reset, setBannerImages, setSubImages, setTimeSlots, setSelectedDate]);
+
+  const onSubmit = async (data: ExperiencesFormData) => {
+    try {
+      // 1️⃣ 스케줄 처리
+      const schedulesToAdd = timeSlots
+        .filter((slot) => slot.startTime && slot.endTime)
+        .map((slot) => ({
+          date: format(new Date(), 'yyyy-MM-dd'),
+          startTime: slot.startTime!,
+          endTime: slot.endTime!,
+        }));
+
+      // 2️⃣ 배너 이미지 처리
+      const bannerUrl = bannerImages[0]
+        ? await uploadActivityImage(bannerImages[0])
+        : bannerUrls[0]; // 기존 URL 유지
+
+      // 3️⃣ 서브 이미지 처리
+      // 삭제할 기존 이미지 ID 추출
+      const subImageIdsToRemove = existingSubImages
+        .filter((img) => !subUrls.includes(img.url)) // 삭제된 것만
+        .map((img) => img.id);
+
+      // 새로 업로드한 파일만 업로드
+      const newFiles = subImages.filter(
+        (file) => file instanceof File
+      ) as File[];
+
+      // 업로드 후 반환되는 URL 배열
+      let subImageUrlsToAdd: string[] = [];
+      if (newFiles.length > 0) {
+        subImageUrlsToAdd = await uploadActivityImages(newFiles);
+        console.log('📌 새로 업로드한 이미지 URL:', subImageUrlsToAdd);
+      }
+
+      // 4️⃣ payload 구성 (기존 이미지는 API에서 자동 유지됨)
+      const payload: UpdateExperiencePayload = {
+        ...data,
+        bannerImageUrl: bannerUrl,
+        subImageIdsToRemove,
+        subImageUrlsToAdd,
+        scheduleIdsToRemove: [],
+        schedulesToAdd,
+      };
+
+      // 5️⃣ API 호출
+      const response = await updateExperience(id, payload);
+      console.log('✅ 체험 수정 성공', response);
+      setIsAlertOpen(true);
+    } catch (error) {
+      console.error('❌ 체험 수정 실패', error);
+    }
+  };
+
+  return (
+    <div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className='flex flex-col gap-[30px]'
+      >
+        <h1 className='font-bold text-18 text-gray-950'>체험 수정하기</h1>
+
+        <FormInput
+          label='제목'
+          variant='experience'
+          placeholder='제목을 입력해 주세요'
+          errorMessage={errors.title?.message}
+          {...register('title', { required: '필수 입력 항목입니다.' })}
+        />
+
+        <Controller
+          name='category'
+          control={control}
+          rules={{ required: '필수 입력 항목입니다.' }}
+          render={({ field, fieldState }) => (
+            <Dropdown
+              label='카테고리'
+              items={[
+                '문화 · 예술',
+                '식음료',
+                '스포츠',
+                '투어',
+                '관광',
+                '웰빙',
+              ]}
+              value={field.value}
+              onChange={field.onChange}
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+
+        <FormInput
+          label='설명'
+          variant='experience'
+          placeholder='체험에 대한 설명을 입력해 주세요'
+          isTextarea={true}
+          errorMessage={errors.description?.message}
+          {...register('description', { required: '필수 입력 항목입니다.' })}
+        />
+
+        <FormInput
+          label='가격'
+          type='number'
+          variant='experience'
+          placeholder='체험 금액을 입력해 주세요'
+          errorMessage={errors.price?.message}
+          {...register('price', {
+            valueAsNumber: true,
+            required: '필수 입력 항목입니다.',
+          })}
+        />
+
+        <FormInput
+          label='주소'
+          placeholder='주소를 입력해 주세요'
+          readOnly
+          {...register('address', { required: '필수 입력 항목입니다.' })}
+          errorMessage={errors.address?.message}
+          onClick={handleAddressClick}
+        />
+
+        <AvailableTimeSlots />
+
+        <UploadBannerImage
+          label='배너'
+          maxImages={1}
+          files={bannerImages}
+          setImages={setBannerImages}
+          existingImages={bannerUrls}
+        />
+
+        <UploadBannerImage
+          label='소개'
+          maxImages={4}
+          files={subImages}
+          setImages={setSubImages}
+          existingImages={subUrls}
+          setExistingImages={setSubUrls}
+        />
+
+        <div className='w-full flex justify-center'>
+          <Button type='submit' className='w-[120px]' variant='primary'>
+            수정하기
+          </Button>
+        </div>
+      </form>
+      <AlertModal
+        isOpen={isAlertOpen}
+        message='체험 등록이 완료되었습니다'
+        onClose={handleCloseModal}
+      />
+    </div>
+  );
+}

--- a/src/app/(global)/(mypage)/myUpdateExperiences/page.tsx
+++ b/src/app/(global)/(mypage)/myUpdateExperiences/page.tsx
@@ -1,7 +1,0 @@
-export default function MyUpdateExperiencesPage() {
-  return (
-    <main>
-      <h1>내 체험 수정</h1>
-    </main>
-  );
-}

--- a/src/services/pages/createImageUrl/api.ts
+++ b/src/services/pages/createImageUrl/api.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/src/services/primitives/apiClient';
+
+export const uploadActivityImage = async (file: File) => {
+  if (!file) throw new Error('업로드할 파일이 없습니다.');
+  const formData = new FormData();
+  formData.append('image', file);
+
+  try {
+    const { data } = await apiClient.post<{ activityImageUrl: string }>(
+      '/activities/image',
+      formData
+    );
+    return data.activityImageUrl;
+  } catch (err) {
+    console.error('❌ 이미지 업로드 실패', err);
+    throw err;
+  }
+};
+
+export const uploadActivityImages = async (files: File[]) => {
+  const urls: string[] = [];
+
+  for (const file of files) {
+    const url = await uploadActivityImage(file);
+    urls.push(url);
+  }
+
+  return urls;
+};

--- a/src/services/pages/myCreateExperiences/api.ts
+++ b/src/services/pages/myCreateExperiences/api.ts
@@ -1,0 +1,23 @@
+import { apiClient } from '../../primitives/apiClient';
+
+interface Schedule {
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface CreateExperienceDto {
+  title: string;
+  category: string;
+  description: string;
+  price: number;
+  address: string;
+  schedules: Schedule[];
+  bannerImageUrl: string;
+  subImageUrls: string[];
+}
+
+export const createExperience = async (data: CreateExperienceDto) => {
+  const res = await apiClient.post('/activities', data);
+  return res.data;
+};

--- a/src/services/pages/myUpdateExperiences/api.ts
+++ b/src/services/pages/myUpdateExperiences/api.ts
@@ -1,17 +1,34 @@
-import { UpdateActivity } from '@/src/types/myActivityType';
 import { apiClient } from '../../primitives/apiClient';
 
-// 내 체험 수정
-export async function patchActivityById(
-  activityId: number,
-  data: UpdateActivity
-): Promise<UpdateActivity> {
-  try {
-    const res = await apiClient.patch(`/my-activities/${activityId}`, data);
-    return res.data;
-  } catch (err) {
-    if (err instanceof Error)
-      console.error('체험 정보를 수정하는데 실패했습니다:', err.message);
-    throw err;
-  }
+export interface UpdateExperiencePayload {
+  title: string;
+  category: string;
+  description: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  subImageUrlsToAdd: string[]; // 기존 + 새로 추가된 이미지
+  subImageIdsToRemove: number[]; // 삭제할 이미지 ID
+  scheduleIdsToRemove: number[]; // 삭제할 스케줄 ID
+  schedulesToAdd: {
+    date: string;
+    startTime: string;
+    endTime: string;
+  }[];
+}
+
+export async function getExperienceDetail(activityId: string) {
+  const response = await apiClient.get(`activities/${activityId}`);
+  return response.data;
+}
+
+export async function updateExperience(
+  activityId: string,
+  payload: UpdateExperiencePayload
+) {
+  const response = await apiClient.patch(
+    `/my-activities/${activityId}`,
+    payload
+  );
+  return response.data;
 }

--- a/src/store/useActivityStore.ts
+++ b/src/store/useActivityStore.ts
@@ -3,11 +3,13 @@ import { create } from 'zustand';
 interface ActivityStore {
   bannerImages: File[];
   subImages: File[];
-  setStoreImages: (key: 'bannerImages' | 'subImages', files: File[]) => void;
+  setBannerImages: (files: File[]) => void;
+  setSubImages: (files: File[]) => void;
 }
 
 export const useActivityStore = create<ActivityStore>((set) => ({
   bannerImages: [],
   subImages: [],
-  setStoreImages: (key, files) => set({ [key]: files }),
+  setBannerImages: (files) => set({ bannerImages: files }),
+  setSubImages: (files) => set({ subImages: files }),
 }));


### PR DESCRIPTION
# 작업내용
- 체험 수정, 체험 이미지 생성 api 추가
- 체험 수정과 등록에 따른 form관리
- UI와 기능에 대한 베타 버전 구현 완료라 해야할까요..

# 해야할것
- 처음부터 돌아보면서 리팩토링을 전체적으로 해야할듯싶습니다.
- 반응형 몇개 적용 안된 것
- 예약 시간 수정 로직 리팩토링
- confirm모달 연결

# 스크린샷
등록 모달 & 성공적인 체험 등록 데이터
<img width="1440" height="775" alt="스크린샷 2025-09-09 오후 7 54 41" src="https://github.com/user-attachments/assets/51281e7b-a1e0-4408-a371-d200f5d4526b" />
수정페이지 체험 데이터 불러오기 & 수정완료
<img width="462" height="749" alt="스크린샷 2025-09-09 오후 7 55 14" src="https://github.com/user-attachments/assets/62727e16-4c09-4764-87ff-b45214c0c816" />



