### PR TITLE
[Fix] useBreakPoint 모바일에서 isMd를 true로 반환하는 에러 수정

### DIFF
--- a/src/hooks/useBreakPoint.ts
+++ b/src/hooks/useBreakPoint.ts
@@ -29,10 +29,11 @@ export function useBreakPoint(): BreakPoint {
         isMd: width >= md,
         isLg: width >= lg,
       };
-      // 이전 값과 동일하면 상태 업데이트하지 않음 -> 불필요한 리렌더링 방지
-      if (breakPoint.isMd !== next.isMd || breakPoint.isLg !== next.isLg) {
-        setBreakpoint(next);
-      }
+
+      setBreakpoint((prev) => {
+        if (prev.isMd === next.isMd && prev.isLg === next.isLg) return prev;
+        return next;
+      });
     };
 
     handleResize();


### PR DESCRIPTION
## 작업 내용
- 데스크탑 -> 모바일로 변경 시 isMd가 true로 반환되는 에러 수정함

## 에러 원인
### 기존 코드
```
if (breakPoint.isMd !== next.isMd || breakPoint.isLg !== next.isLg) {
  setBreakpoint(next);
}
```
- 기존 코드 는 훅 안에서 breakPoint state 변수를 직접 참조하였음
- useEffect나 이벤트 핸들러 안에서 breakPoint를 직접 참조하면 클로저에 묶인 값이 최신 상태와 다를 수 있기 때문에 resize 이벤트가 빠르게 발생하는 경우라면 이전 상태를 반영하지 못할 수 있음

### 변경 코드
```
setBreakpoint((prev) => {
  if (prev.isMd === next.isMd && prev.isLg === next.isLg) return prev;
  return next;
});
```
- setState에 함수로 업데이트하도록 적용함
- 함수형으로 하면 항상 최신 값을 받아서 비교할 수 있어서 클로저 문제를 피할 수 있고, 이전 값과 동일하면 prev를 반환하고 state를 변경하지 않음

## 스크린샷
- 디버깅 내용입니다.
<img width="416" height="171" alt="image" src="https://github.com/user-attachments/assets/e3515d57-f01a-4455-8d74-5f7843553fc4" />
